### PR TITLE
ignore datetime.datetime.utcnow warning

### DIFF
--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -1,3 +1,5 @@
+import warnings
+warnings.filterwarnings(action="ignore", message=r"datetime.datetime.utcnow")
 import importlib
 import json
 import os


### PR DESCRIPTION
### **User description**
Disable annoying warnings of Datetime package in console

<img width="1472" alt="image" src="https://github.com/user-attachments/assets/a90c0539-0b12-42cb-8e7f-faff18b9f488" />


___

### **PR Type**
enhancement


___

### **Description**
- Suppresses warnings related to `datetime.datetime.utcnow`

- Adds warning filter at the top of `bench_helper.py`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bench_helper.py</strong><dd><code>Suppress datetime.datetime.utcnow warnings using filter</code>&nbsp; &nbsp; </dd></summary>
<hr>

frappe/utils/bench_helper.py

<li>Imports <code>warnings</code> module at the top of the file<br> <li> Adds filter to ignore warnings matching <code>datetime.datetime.utcnow</code>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/frappe/pull/5/files#diff-da3d37a947b063a4c677cd4fe591a545a7a963ee776fa51b5ceee2cacf7b802c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>