### PR TITLE
setup: readonly system timezone and default user timezone

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -131,6 +131,7 @@
    "fieldname": "time_zone",
    "fieldtype": "Select",
    "label": "Time Zone",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -696,7 +697,7 @@
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2025-06-16 03:43:38.552252",
+ "modified": "2025-06-17 06:42:49.877281",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -206,6 +206,7 @@
    "options": "Language"
   },
   {
+   "default": "Asia/Ho_Chi_Minh",
    "fieldname": "time_zone",
    "fieldtype": "Autocomplete",
    "label": "Time Zone"
@@ -880,7 +881,7 @@
   }
  ],
  "make_attachments_public": 1,
- "modified": "2025-06-09 12:06:11.209293",
+ "modified": "2025-06-17 06:42:05.801103",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",


### PR DESCRIPTION
### **User description**
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->


___

### **PR Type**
Enhancement


___

### **Description**
• Make system timezone field read-only in System Settings
• Set default timezone to Asia/Ho_Chi_Minh for User doctype


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_settings.json</strong><dd><code>Make system timezone field read-only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frappe/core/doctype/system_settings/system_settings.json

• Added read_only property to time_zone field<br> • Updated modified <br>timestamp


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/frappe/pull/14/files#diff-487fe242b35a4df6a7960e65354165291a57e3a4475b8e8307b4a2c5e2cab93d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>user.json</strong><dd><code>Set default timezone for users</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frappe/core/doctype/user/user.json

• Added default value "Asia/Ho_Chi_Minh" to time_zone field<br> • Updated <br>modified timestamp


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/frappe/pull/14/files#diff-7765efad85cc0110f0e9f719d6faca36640a242ba45ffae66ed147c2bd860cb1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>