### PR TITLE
fix(webhook): missing webhook on Lead, Sale Order

### DIFF
--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -101,7 +101,8 @@ def flush_webhook_execution_queue():
 	for instance in unique_last_instances:
 		frappe.enqueue(
 			"frappe.integrations.doctype.webhook.webhook.enqueue_webhook",
-			doc=instance.doc,
+			doc_doctype=instance.doc.doctype,
+			doc_name=instance.doc.name,
 			webhook=instance.webhook,
 			now=frappe.flags.in_test,
 			queue=instance.webhook.background_jobs_queue or "default",

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -155,10 +155,20 @@ def get_context(doc):
 	return {"doc": doc, "utils": get_safe_globals().get("frappe").get("utils")}
 
 
-def enqueue_webhook(doc, webhook) -> None:
+def enqueue_webhook(doc=None, webhook=None, doc_doctype=None, doc_name=None) -> None:
 	request_url = headers = data = r = None
 	try:
 		webhook: Webhook = frappe.get_doc("Webhook", webhook.get("name"))
+		
+		# Resolve document: prefer primitive args to avoid pickling issues
+		if doc is None:
+			if doc_doctype and doc_name:
+				doc = frappe.get_doc(doc_doctype, doc_name)
+			else:
+				# If neither doc nor (doctype, name) are provided, bail out
+				frappe.logger().debug({"enqueue_webhook_error": "Missing document for webhook enqueue"})
+				return
+		
 		request_url = webhook.request_url
 		if webhook.is_dynamic_url:
 			request_url = frappe.render_template(webhook.request_url, get_context(doc))
@@ -167,7 +177,8 @@ def enqueue_webhook(doc, webhook) -> None:
 
 	except Exception as e:
 		frappe.logger().debug({"enqueue_webhook_error": e})
-		log_request(webhook.name, doc.name, request_url, headers, data)
+		doc_name_for_log = doc.name if doc else doc_name
+		log_request(webhook.name, doc_name_for_log, request_url, headers, data)
 		return
 
 	for i in range(3):


### PR DESCRIPTION
Bug Fix:
In ERPNext, when creating a webhook for Lead or Sales Order, no matter which event is selected (Created, Updated, Deleted), the webhook is not sent. Meanwhile, webhooks of other DocTypes work normally.

Current status:
- The webhook event is put into the queue.

- But it cannot be enqueued for sending.
- Details can be observed in PR: jemmia-diamond/frappe/pull/22.