### PR TITLE
fix(webhook): handle delete events properly in webhook execution

### DIFF
--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -111,13 +111,10 @@ def flush_webhook_execution_queue():
 		}
 		
 		if is_delete_event:
-			# Pass full doc data for delete events since doc is deleted from DB
-			# Use as_dict to get clean dict without methods/attributes
 			doc_data = instance.doc.as_dict(convert_dates_to_str=True)
 			enqueue_kwargs["doc"] = doc_data
 			enqueue_kwargs["is_delete_event"] = True
 		else:
-			# For other events, pass doctype and name to fetch fresh data
 			enqueue_kwargs["doc_doctype"] = instance.doc.doctype
 			enqueue_kwargs["doc_name"] = instance.doc.name
 			

--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -99,11 +99,20 @@ def flush_webhook_execution_queue():
 	unique_last_instances.reverse()
 
 	for instance in unique_last_instances:
-		frappe.enqueue(
-			"frappe.integrations.doctype.webhook.webhook.enqueue_webhook",
-			doc_doctype=instance.doc.doctype,
-			doc_name=instance.doc.name,
-			webhook=instance.webhook,
-			now=frappe.flags.in_test,
-			queue=instance.webhook.background_jobs_queue or "default",
-		)
+		# For delete events (on_trash), document is already deleted from DB
+		# So we only pass basic info and let enqueue_webhook handle it appropriately
+		is_delete_event = instance.webhook.get("webhook_docevent") == "on_trash"
+		
+		enqueue_kwargs = {
+			"method": "frappe.integrations.doctype.webhook.webhook.enqueue_webhook",
+			"doc_doctype": instance.doc.doctype,
+			"doc_name": instance.doc.name,
+			"webhook": instance.webhook,
+			"now": frappe.flags.in_test,
+			"queue": instance.webhook.background_jobs_queue or "default",
+		}
+		
+		if is_delete_event:
+			enqueue_kwargs["is_delete_event"] = True
+			
+		frappe.enqueue(**enqueue_kwargs)

--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -100,19 +100,25 @@ def flush_webhook_execution_queue():
 
 	for instance in unique_last_instances:
 		# For delete events (on_trash), document is already deleted from DB
-		# So we only pass basic info and let enqueue_webhook handle it appropriately
+		# So we pass the doc data directly as it won't be available in DB
 		is_delete_event = instance.webhook.get("webhook_docevent") == "on_trash"
 		
 		enqueue_kwargs = {
 			"method": "frappe.integrations.doctype.webhook.webhook.enqueue_webhook",
-			"doc_doctype": instance.doc.doctype,
-			"doc_name": instance.doc.name,
 			"webhook": instance.webhook,
 			"now": frappe.flags.in_test,
 			"queue": instance.webhook.background_jobs_queue or "default",
 		}
 		
 		if is_delete_event:
+			# Pass full doc data for delete events since doc is deleted from DB
+			# Use as_dict to get clean dict without methods/attributes
+			doc_data = instance.doc.as_dict(convert_dates_to_str=True)
+			enqueue_kwargs["doc"] = doc_data
 			enqueue_kwargs["is_delete_event"] = True
+		else:
+			# For other events, pass doctype and name to fetch fresh data
+			enqueue_kwargs["doc_doctype"] = instance.doc.doctype
+			enqueue_kwargs["doc_name"] = instance.doc.name
 			
 		frappe.enqueue(**enqueue_kwargs)

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -155,19 +155,29 @@ def get_context(doc):
 	return {"doc": doc, "utils": get_safe_globals().get("frappe").get("utils")}
 
 
-def enqueue_webhook(doc=None, webhook=None, doc_doctype=None, doc_name=None) -> None:
+def enqueue_webhook(doc=None, webhook=None, doc_doctype=None, doc_name=None, is_delete_event=False) -> None:
 	request_url = headers = data = r = None
 	try:
 		webhook: Webhook = frappe.get_doc("Webhook", webhook.get("name"))
 		
-		# Resolve document: prefer primitive args to avoid pickling issues
-		if doc is None:
-			if doc_doctype and doc_name:
-				doc = frappe.get_doc(doc_doctype, doc_name)
-			else:
-				# If neither doc nor (doctype, name) are provided, bail out
-				frappe.logger().debug({"enqueue_webhook_error": "Missing document for webhook enqueue"})
-				return
+		# For delete events, we don't need to fetch the document as it's already deleted
+		if is_delete_event:
+			# Create a minimal doc object with just the name and doctype for delete events
+			doc = frappe._dict({
+				"name": doc_name,
+				"doctype": doc_doctype
+			})
+
+			return doc
+		else:
+			# Resolve document: prefer primitive args to avoid pickling issues
+			if doc is None:
+				if doc_doctype and doc_name:
+					doc = frappe.get_doc(doc_doctype, doc_name)
+				else:
+					# If neither doc nor (doctype, name) are provided, bail out
+					frappe.logger().debug({"enqueue_webhook_error": "Missing document for webhook enqueue"})
+					return
 		
 		request_url = webhook.request_url
 		if webhook.is_dynamic_url:

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -160,24 +160,18 @@ def enqueue_webhook(doc=None, webhook=None, doc_doctype=None, doc_name=None, is_
 	try:
 		webhook: Webhook = frappe.get_doc("Webhook", webhook.get("name"))
 		
-		# For delete events, we don't need to fetch the document as it's already deleted
-		if is_delete_event:
-			# Create a minimal doc object with just the name and doctype for delete events
-			doc = frappe._dict({
-				"name": doc_name,
-				"doctype": doc_doctype
-			})
-
-			return doc
-		else:
-			# Resolve document: prefer primitive args to avoid pickling issues
-			if doc is None:
-				if doc_doctype and doc_name:
-					doc = frappe.get_doc(doc_doctype, doc_name)
-				else:
-					# If neither doc nor (doctype, name) are provided, bail out
-					frappe.logger().debug({"enqueue_webhook_error": "Missing document for webhook enqueue"})
-					return
+		# Resolve document: prefer primitive args to avoid pickling issues
+		if doc is None:
+			if doc_doctype and doc_name:
+				doc = frappe.get_doc(doc_doctype, doc_name)
+			else:
+				# If neither doc nor (doctype, name) are provided, bail out
+				frappe.logger().debug({"enqueue_webhook_error": "Missing document for webhook enqueue"})
+				return
+		elif isinstance(doc, dict):
+			# For delete events, doc is already a dict with all data
+			# Convert to frappe._dict to maintain compatibility
+			doc = frappe._dict(doc)
 		
 		request_url = webhook.request_url
 		if webhook.is_dynamic_url:
@@ -266,11 +260,21 @@ def get_webhook_headers(doc, webhook):
 
 def get_webhook_data(doc, webhook):
 	data = {}
-	doc = doc.as_dict(convert_dates_to_str=True)
+	
+	# Convert doc to dict if it's a Document object
+	if isinstance(doc, dict):
+		# Already a dict (e.g., from delete events)
+		doc_dict = doc
+	elif hasattr(doc, 'as_dict') and callable(getattr(doc, 'as_dict', None)):
+		doc_dict = doc.as_dict(convert_dates_to_str=True)
+	else:
+		# Fallback: try to use doc as-is if it's dict-like
+		doc_dict = doc if isinstance(doc, dict) else {}
 
 	if webhook.webhook_data:
-		data = {w.key: doc.get(w.fieldname) for w in webhook.webhook_data}
+		data = {w.key: doc_dict.get(w.fieldname) for w in webhook.webhook_data}
 	elif webhook.webhook_json:
+		# For JSON template, use original doc object for better context
 		data = frappe.render_template(webhook.webhook_json, get_context(doc))
 		data = json.loads(data)
 


### PR DESCRIPTION
### **User description**
Fixing delete event topic get non exist data.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed webhook execution for `on_trash` (delete) events by passing document data directly

- Modified `enqueue_webhook` to accept document data as dict for delete events

- Updated `get_webhook_data` to handle both Document objects and dict inputs

- Added `is_delete_event` parameter to distinguish delete operations from other events


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["flush_webhook_execution_queue"] -- "detects on_trash event" --> B["Pass doc.as_dict()"]
  B -- "enqueue with doc data" --> C["enqueue_webhook"]
  C -- "handle dict input" --> D["get_webhook_data"]
  D -- "process webhook" --> E["Send webhook request"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Handle delete events by passing document data directly</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frappe/integrations/doctype/webhook/__init__.py

<ul><li>Detect <code>on_trash</code> events and pass document data as dict instead of <br>doctype/name<br> <li> Restructure enqueue call to conditionally pass <code>doc</code> data or <br><code>doc_doctype</code>/<code>doc_name</code><br> <li> Add <code>is_delete_event</code> flag to distinguish delete operations</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/frappe/pull/26/files#diff-457ffb951bbce81a360b512ee154fb801e8b4122d4592d061d68757facffea11">+20/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>webhook.py</strong><dd><code>Support dict document data in webhook processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frappe/integrations/doctype/webhook/webhook.py

<ul><li>Add <code>is_delete_event</code> parameter to <code>enqueue_webhook</code> function signature<br> <li> Convert dict input to <code>frappe._dict</code> for delete events compatibility<br> <li> Update <code>get_webhook_data</code> to handle both Document objects and dict <br>inputs<br> <li> Add type checking and fallback logic for document data conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/frappe/pull/26/files#diff-b5a4968c84c659cea1dd0bb4c6e0359ef75cbaa2c115867e975e575857301bf8">+17/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

