### PR TITLE
fix: if it a dict, return as it is

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -656,7 +656,7 @@ class BaseDocument:
 		for fieldname in table_fieldnames:
 			children = getattr(self, fieldname, None) or []
 			doc[fieldname] = [
-				d.as_dict(
+				d if isinstance(d, dict) else d.as_dict(
 					convert_dates_to_str=convert_dates_to_str,
 					no_nulls=no_nulls,
 					no_default_fields=no_default_fields,


### PR DESCRIPTION
# Fix: Handle dict objects in BaseDocument.as_dict()

## Issue

During v15 to v16 migration, web login fails with:

```python
AttributeError: 'dict' object has no attribute 'as_dict'
File "apps/frappe/frappe/model/base_document.py", line 659, in as_dict
```

Users cannot log in via web interface after migration.

## Root Cause

The `as_dict()` method assumes all child table items are Document objects with an `as_dict()` method. During migration, cached User documents contain child table items as plain dict objects instead. When the code tries to call `d.as_dict()` on a dict, it fails.

## Failure Path

```
Web Login
  → frappe.sessions.get()
  → get_bootinfo()
  → UserPermissions.__init__()
  → setup_user()
  → frappe.cache.hget("user_doc", username, get_user_doc)
  → frappe.get_doc("User", username).as_dict()
  → [CRASH] d.as_dict() on dict object
```

## Solution

Add type checking to handle both dict and Document objects.

**File:** `apps/frappe/frappe/model/base_document.py`

```python
doc[fieldname] = [
    d if isinstance(d, dict) else d.as_dict(
        convert_dates_to_str=convert_dates_to_str,
        no_nulls=no_nulls,
        no_default_fields=no_default_fields,
        no_child_table_fields=no_child_table_fields,
        no_private_properties=no_private_properties,
    )
    for d in children
]
```

### How It Works

The fix checks the type of each child table item:
- If `d` is already a dict: use it as-is
- If `d` is a Document object: call `d.as_dict()` with parameters

This handles both cached data (dicts) and fresh data (Document objects) without breaking existing functionality.
