### PR TITLE
Migrate/from v15 21april

### DIFF
--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -11,6 +11,7 @@
   "cb_doc_events",
   "webhook_docevent",
   "enabled",
+  "enable_log",
   "sb_condition",
   "condition",
   "cb_condition",
@@ -154,6 +155,13 @@
    "fieldname": "enabled",
    "fieldtype": "Check",
    "label": "Enabled"
+  },
+  {
+   "default": "1",
+   "description": "When enabled, webhook requests will be logged to Webhook Request Log",
+   "fieldname": "enable_log",
+   "fieldtype": "Check",
+   "label": "Enable Request Log"
   },
   {
    "default": "POST",

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -33,6 +33,7 @@ class Webhook(Document):
 
 		background_jobs_queue: DF.Autocomplete | None
 		condition: DF.SmallText | None
+		enable_log: DF.Check
 		enable_security: DF.Check
 		enabled: DF.Check
 		is_dynamic_url: DF.Check
@@ -170,7 +171,8 @@ def enqueue_webhook(doc=None, webhook=None, doc_doctype=None, doc_name=None, is_
 
 	except Exception as e:
 		frappe.logger().debug({"enqueue_webhook_error": e})
-		log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data)
+		doc_name_for_log = doc.name if doc else doc_name
+		log_request(webhook, doc.doctype, doc_name_for_log, request_url, headers, data)
 		return
 
 	for i in range(3):
@@ -184,16 +186,16 @@ def enqueue_webhook(doc=None, webhook=None, doc_doctype=None, doc_name=None, is_
 			)
 			r.raise_for_status()
 			frappe.logger().debug({"webhook_success": r.text})
-			log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data, r)
+			log_request(webhook, doc.doctype, doc.name, request_url, headers, data, r)
 			break
 
 		except requests.exceptions.ReadTimeout as e:
 			frappe.logger().debug({"webhook_error": e, "try": i + 1})
-			log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data)
+			log_request(webhook, doc.doctype, doc.name, request_url, headers, data)
 
 		except Exception as e:
 			frappe.logger().debug({"webhook_error": e, "try": i + 1})
-			log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data, r)
+			log_request(webhook, doc.doctype, doc.name, request_url, headers, data, r)
 			sleep(3 * i + 1)
 			if i != 2:
 				continue
@@ -203,7 +205,7 @@ def enqueue_webhook(doc=None, webhook=None, doc_doctype=None, doc_name=None, is_
 
 
 def log_request(
-	webhook: str,
+	webhook: str | Webhook,
 	doctype: str,
 	docname: str,
 	url: str,
@@ -211,10 +213,22 @@ def log_request(
 	data: dict,
 	res: requests.Response | None = None,
 ):
+	if isinstance(webhook, str):
+		try:
+			webhook_doc = frappe.get_doc("Webhook", webhook)
+		except Exception:
+			webhook_doc = frappe._dict({"name": webhook, "enable_log": 1})
+	else:
+		webhook_doc = webhook
+
+	enable_log = webhook_doc.get("enable_log", 1)
+	if not enable_log:
+		return
+
 	request_log = frappe.get_doc(
 		{
 			"doctype": "Webhook Request Log",
-			"webhook": webhook,
+			"webhook": webhook_doc.name,
 			"reference_doctype": doctype,
 			"reference_document": docname,
 			"user": frappe.session.user if frappe.session.user else None,

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -1,4 +1,5 @@
 [pre_model_sync]
+frappe.patches.v16_0.enable_setup_complete #01-07-2025 re-run-patch
 frappe.patches.v15_0.remove_implicit_primary_key
 frappe.patches.v12_0.remove_deprecated_fields_from_doctype #3
 execute:frappe.utils.global_search.setup_global_search_table()
@@ -43,7 +44,6 @@ execute:frappe.db.sql("delete from tabSessions where user is null")
 execute:frappe.delete_doc("DocType", "Backup Manager")
 execute:frappe.permissions.reset_perms("Web Page")
 execute:frappe.db.sql("delete from `tabWeb Page` where ifnull(template_path, '')!=''")
-execute:frappe.core.doctype.language.language.update_language_names() # 2017-04-12
 execute:frappe.db.set_value("Print Settings", "Print Settings", "add_draft_heading", 1)
 execute:frappe.db.set_default('language', '')
 execute:frappe.db.sql("update tabCommunication set communication_date = creation where time(communication_date) = 0")
@@ -195,6 +195,8 @@ frappe.patches.v15_0.copy_disable_prepared_report_to_prepared_report
 execute:frappe.reload_doc("desk", "doctype", "Form Tour")
 execute:frappe.delete_doc('Page', 'recorder', ignore_missing=True, force=True)
 frappe.patches.v14_0.modify_value_column_size_for_singles
+frappe.integrations.doctype.oauth_bearer_token.patches.clear_old_tokens
+execute:frappe.db.truncate("Desktop Icon")
 
 [post_model_sync]
 execute:frappe.get_doc('Role', 'Guest').save() # remove desk access
@@ -232,12 +234,29 @@ frappe.patches.v15_0.set_file_type
 frappe.core.doctype.data_import.patches.remove_stale_docfields_from_legacy_version
 frappe.patches.v15_0.validate_newsletter_recipients
 frappe.patches.v15_0.sanitize_workspace_titles
+frappe.patches.v15_0.migrate_role_profile_to_table_multi_select
+frappe.patches.v15_0.migrate_session_data
 frappe.custom.doctype.property_setter.patches.remove_invalid_fetch_from_expressions
+frappe.patches.v16_0.switch_default_sort_order
 frappe.integrations.doctype.oauth_client.patches.set_default_allowed_role_in_oauth_client
 frappe.patches.v16_0.add_app_launcher_in_navbar_settings
-frappe.patches.v15_0.remove_workspace_settings_navbar_items
+frappe.desk.doctype.workspace.patches.update_app
 frappe.patches.v16_0.move_role_desk_settings_to_user
-frappe.patches.v14_0.fix_user_settings_collation
-execute:frappe.core.doctype.system_settings.system_settings.sync_system_settings 
 frappe.printing.doctype.print_format.patches.sets_wkhtmltopdf_as_default_for_pdf_generator_field
-frappe.patches.v16_0.social_eps_deprecation_warning
+frappe.patches.v14_0.fix_user_settings_collation
+execute:frappe.call("frappe.core.doctype.system_settings.system_settings.sync_system_settings")
+frappe.patches.v15_0.migrate_to_utm
+frappe.patches.v16_0.add_module_deprecation_warning
+frappe.patches.v16_0.auto_generate_desktop_icon_and_sidebar
+frappe.patches.v16_0.add_private_workspaces_to_sidebar
+frappe.core.doctype.communication_link.patches.copy_communication_date_to_link
+frappe.core.doctype.communication.patches.drop_ref_dt_dn_index
+frappe.patches.v16_0.change_link_type_to_workspace_sidebar
+frappe.patches.v16_0.add_standard_field_in_workspace_sidebar
+execute:frappe.db.set_single_value("Desktop Settings", "icon_style", "Solid")
+execute:frappe.delete_doc_if_exists("Workspace Sidebar", "Productivity")
+frappe.patches.v16_0.unset_standard_field_for_auto_generated_icons
+execute:from frappe.email.doctype.notification.notification import install_notification_templates; install_notification_templates()
+execute:frappe.db.set_value("Email Account", {}, "add_x_original_from", 1)
+execute:frappe.db.set_value("Email Account", {}, "add_reply_to_header", 1)
+frappe.patches.v16_0.set_reply_to_header


### PR DESCRIPTION
#### Changes
- Merge #48 
- REVERT #47 

Conflicts:
- in Merge #48 
  - frappe/integrations/doctype/webhook/webhook.py
```
<<<<<<< HEAD
		log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data)
=======
		doc_name_for_log = doc.name if doc else doc_name
		log_request(webhook, doc_name_for_log, request_url, headers, data)
>>>>>>> 70ffdb0079 (Merge pull request #48 from jemmia-diamond/feature/webhook/added-log-enabled-button)
```
=> both with modified
```
log_request(webhook, doc.doctype, doc_name_for_log, request_url, headers, data)
```
<hr>

```
<<<<<<< HEAD
			log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data, r)
=======
			log_request(webhook, doc.name, request_url, headers, data, r)
>>>>>>> 70ffdb0079 (Merge pull request #48 from jemmia-diamond/feature/webhook/added-log-enabled-button)
```
=> both with modified
```
			log_request(webhook, doc.doctype, doc.name, request_url, headers, data, r)
```
<hr>

```
<<<<<<< HEAD
			log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data)

		except Exception as e:
			frappe.logger().debug({"webhook_error": e, "try": i + 1})
			log_request(webhook.name, doc.doctype, doc.name, request_url, headers, data, r)
=======
			log_request(webhook, doc.name, request_url, headers, data)

		except Exception as e:
			frappe.logger().debug({"webhook_error": e, "try": i + 1})
			log_request(webhook, doc.name, request_url, headers, data, r)
>>>>>>> 70ffdb0079 (Merge pull request #48 from jemmia-diamond/feature/webhook/added-log-enabled-button)
```
=> both with modified
```
        log_request(webhook, doc.doctype, doc.name, request_url, headers, data)

		except Exception as e:
			frappe.logger().debug({"webhook_error": e, "try": i + 1})
			log_request(webhook, doc.doctype, doc.name, request_url, headers, data, r)
```
<hr>


```
<<<<<<< HEAD
	webhook: str,
	doctype: str,
=======
	webhook: str | Webhook,
>>>>>>> 70ffdb0079 (Merge pull request #48 from jemmia-diamond/feature/webhook/added-log-enabled-button)
```
=> both with modified
```
	webhook: str | Webhook,
	doctype: str,
```
<hr>

```
<<<<<<< HEAD
			"webhook": webhook,
			"reference_doctype": doctype,
=======
			"webhook": webhook_doc.name,
>>>>>>> 70ffdb0079 (Merge pull request #48 from jemmia-diamond/feature/webhook/added-log-enabled-button)
```
=> both with modified
```
			"webhook": webhook_doc.name,
			"reference_doctype": doctype,
```