### PR TITLE
fix: applied last_sidebar, overdrive default frappe behavior for chan…

### DIFF
--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -252,6 +252,11 @@ frappe.ui.Sidebar = class Sidebar {
 		this.workspace_sidebar_items = updated_items;
 	}
 	setup(workspace_title) {
+		// PATCH (sidebar-persistence): Frappe only keeps sidebar_title in memory.
+		// On hard refresh, memory is wiped and sidebar renders blank.
+		// We persist the last active sidebar to localStorage so it can be restored.
+		localStorage.setItem("last_sidebar", workspace_title);
+
 		if (!this.onboarding_widget) {
 			this.onboarding_widget = {};
 		}
@@ -621,6 +626,20 @@ frappe.ui.Sidebar = class Sidebar {
 
 	set_workspace_sidebar(router) {
 		try {
+			// PATCH (sidebar-persistence): On hard refresh, this.sidebar_title is null
+			// because memory was wiped. Frappe's original logic then fails to find the correct
+			// sidebar and renders blank. We restore the last known sidebar from localStorage
+			// before falling through to Frappe's logic.
+			// Guard: skip if workspace no longer exists or user has no access (not in boot).
+			// Ref: https://github.com/frappe/frappe/issues/36317
+			if (!this.sidebar_title) {
+				let saved = localStorage.getItem("last_sidebar");
+				if (saved && frappe.boot.workspace_sidebar_item[saved.toLowerCase()]) {
+					frappe.app.sidebar.setup(saved);
+					return;
+				}
+			}
+
 			let route = frappe.get_route();
 			let view, entity_name;
 			switch (route.length) {


### PR DESCRIPTION
#### Changes
- Fixing sidebar auto change when refresh, an known issue in Frappe


Step to repoduce:
1. Click on Desktop icon ( in which will take us to an Workspace)
2. Click on Doctype (Lead, Payment Entry, etc.) 
3. Hit refresh or hard refresh
4. Observe that our Sidebar is now chaging to Doctype Module instead of our previously choosing Workspace/ Desktop Ion

Note:
- In v15: we got  **ONE pinned** sidebar and multiple workspace
- In v16: Each sidebar (named "Workspace Sidebar" ) belong each workspace 

Refer to these Issues:
1. https://github.com/frappe/frappe/issues/36546
3. https://github.com/frappe/frappe/issues/36317